### PR TITLE
Testes API Agendar cortes + Postar imagens

### DIFF
--- a/Hair.Domain/Entities/ImageEntity.cs
+++ b/Hair.Domain/Entities/ImageEntity.cs
@@ -7,6 +7,7 @@ namespace Hair.Domain.Entities
     /// </summary>
     public class ImageEntity : BaseEntity
     {
+
         public Guid SaloonId { get; set; }
         public byte[] Img { get; set; }
 

--- a/Hair.Tests/Services/PostImageServiceTest.cs
+++ b/Hair.Tests/Services/PostImageServiceTest.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Hair.Application.Common;
+using Hair.Application.Dto;
+using Hair.Application.Extensions;
+using Hair.Application.Services;
+using Hair.Domain.Entities;
+using Hair.Repository.Interfaces;
+using Moq;
+using Xunit;
+
+namespace Hair.Tests.Application.Services
+{
+    public class PostImageServiceTests
+    {
+        private readonly Mock<IBaseRepository<ImageEntity>> _mockImageRepository;
+        private readonly Mock<IBaseRepository<UserEntity>> _mockUserRepository;
+        private readonly PostImageService _postImageService;
+
+        public PostImageServiceTests()
+        {
+            _mockImageRepository = new Mock<IBaseRepository<ImageEntity>>();
+            _mockUserRepository = new Mock<IBaseRepository<UserEntity>>();
+            _postImageService = new PostImageService(_mockImageRepository.Object, _mockUserRepository.Object);
+        }
+
+        [Fact]
+        public void Post_WhenUserIsNull_ReturnsNotFoundError()
+        {
+            // Arrange
+            var dto = new PostImageDto(Guid.NewGuid(), "image");
+
+            _mockUserRepository.Setup(repo => repo.GetById(dto.UserID)).Returns((UserEntity)null);
+
+            // Act
+            var actual = _postImageService.Post(dto);
+            var expected = BaseDtoExtension.NotFound();
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
+
+        [Fact]
+        public void Post_WhenImageIsNull_ReturnsNotNullError()
+        {
+            // Arrange
+            var user = new UserEntity { Id = Guid.NewGuid() };
+            var dto = new PostImageDto(user.Id, null);
+
+            _mockUserRepository.Setup(repo => repo.GetById(dto.UserID)).Returns(user);
+
+            // Act
+            var actual = _postImageService.Post(dto);
+            var expected = BaseDtoExtension.NotNull("Imagem");
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
+
+        [Fact]
+        public void Post_WhenImageIsNotNull_ReturnsSuccess()
+        {
+            // Arrange
+            var user = new UserEntity { Id = Guid.NewGuid() };
+            var imageData = new byte[] { 0x00, 0x01, 0x02 }; // substituir com o dado da imagem
+            var hexString = BitConverter.ToString(imageData).Replace("-", "");
+            var dto = new PostImageDto(user.Id, hexString);
+
+            _mockUserRepository.Setup(repo => repo.GetById(dto.UserID)).Returns(user);
+
+            // Act
+            var actual = _postImageService.Post(dto);
+            var expected = BaseDtoExtension.Sucess();
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
+    }
+}

--- a/Hair.Tests/Services/ScheduleHaircutServiceTest.cs
+++ b/Hair.Tests/Services/ScheduleHaircutServiceTest.cs
@@ -157,5 +157,38 @@ namespace Hair.Tests.Application.Services
             Assert.Equal(expected._StatusCode, actual._StatusCode);
         }
 
+        [Fact]
+        public void Schedule_WhenHaircutCanBeScheduled_ReturnsSuccess()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var haircutTime = "02/04/2004";
+            var clientDto = new ClientEntity("Bruno", "elefante@outlook.com", "40028922");
+            var dto = new ScheduleHaircutDto(userId, haircutTime, true, clientDto);
+
+            var user = new UserEntity { Id = userId };
+
+            _mockUserRepository.Setup(repo => repo.GetById(dto.UserID)).Returns(user);
+
+            _mockHaircutRepository.Setup(repo => repo.GetAll()).Returns(new List<HaircutEntity>());
+
+            _mockHaircutRepository.Setup(repo => repo.Create(It.IsAny<HaircutEntity>())).Callback<HaircutEntity>(haircut =>
+            {
+                user.Haircuts.Add(haircut);
+            });
+
+            _mockUserRepository.Setup(repo => repo.Update(It.IsAny<UserEntity>())).Callback<UserEntity>(updatedUser =>
+            {
+                user = updatedUser;
+            });
+
+            // Act
+            var actual = _scheduleHaircutService.Schedule(dto);
+            var expected = BaseDtoExtension.Sucess();
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
     }
 }

--- a/Hair.Tests/Services/ScheduleHaircutServiceTest.cs
+++ b/Hair.Tests/Services/ScheduleHaircutServiceTest.cs
@@ -1,0 +1,161 @@
+﻿using Hair.Application.Common;
+using Hair.Application.Dto;
+using Hair.Application.Extensions;
+using Hair.Application.Services;
+using Hair.Domain.Entities;
+using Hair.Repository.Interfaces;
+using Moq;
+using System.Net;
+using Xunit;
+
+namespace Hair.Tests.Application.Services
+{
+    public class ScheduleHaircutServiceTests
+    {
+        private readonly Mock<IBaseRepository<UserEntity>> _mockUserRepository;
+        private readonly Mock<IBaseRepository<HaircutEntity>> _mockHaircutRepository;
+        private readonly ScheduleHaircutService _scheduleHaircutService;
+
+        public ScheduleHaircutServiceTests()
+        {
+            _mockUserRepository = new Mock<IBaseRepository<UserEntity>>();
+            _mockHaircutRepository = new Mock<IBaseRepository<HaircutEntity>>();
+            _scheduleHaircutService = new ScheduleHaircutService(_mockUserRepository.Object, _mockHaircutRepository.Object);
+        }
+
+        [Fact]
+        public void Schedule_WhenNotConfirmed_ReturnsRequestCanceledError()
+        {
+            // Arrange
+            var dto = new ScheduleHaircutDto(Guid.NewGuid(), null, false, null);
+
+            // Act
+            var actual = _scheduleHaircutService.Schedule(dto);
+            var expected = BaseDtoExtension.RequestCanceled();
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
+
+        [Fact]
+        public void Schedule_WhenUserIsNull_ReturnsNotNullError()
+        {
+            // Arrange
+            var dto = new ScheduleHaircutDto(Guid.NewGuid(), null, true, null);
+
+            _mockUserRepository.Setup(repo => repo.GetById(dto.UserID)).Returns((UserEntity)null);
+
+            // Act
+            var actual = _scheduleHaircutService.Schedule(dto);
+            var expected = BaseDtoExtension.NotNull("Usuário");
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
+
+        [Fact]
+        public void Schedule_WhenHaircuteTimeIsNull_ReturnsNotNullError()
+        {
+            // Arrange
+            var user = new UserEntity { Id = Guid.NewGuid() };
+            var dto = new ScheduleHaircutDto(user.Id, null, true, null);
+
+            _mockUserRepository.Setup(repo => repo.GetById(dto.UserID)).Returns(user);
+
+            // Act
+            var actual = _scheduleHaircutService.Schedule(dto);
+            var expected = BaseDtoExtension.NotNull("Horário");
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
+
+        [Fact]
+        public void Schedule_WhenClientNameIsNull_ReturnsNotNullError()
+        {
+            // Arrange
+            var user = new UserEntity { Id = Guid.NewGuid() };
+            var dto = new ScheduleHaircutDto(user.Id, "05/04/2023", true, new ClientEntity { Name = null });
+
+            _mockUserRepository.Setup(repo => repo.GetById(dto.UserID)).Returns(user);
+
+            // Act
+            var actual = _scheduleHaircutService.Schedule(dto);
+            var expected = BaseDtoExtension.NotNull("Nome do cliente");
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
+
+        [Fact]
+        public void Schedule_WhenClientPhoneNumberIsNull_ReturnsNotNullError()
+        {
+            // Arrange
+            var user = new UserEntity { Id = Guid.NewGuid() };
+            var dto = new ScheduleHaircutDto(user.Id, "02/04/05", true, new ClientEntity { Name = "Banana", Email = "Elefante@gmail.com", PhoneNumber = null });
+
+            _mockUserRepository.Setup(repo => repo.GetById(dto.UserID)).Returns(user);
+
+            // Act
+            var actual = _scheduleHaircutService.Schedule(dto);
+            var expected = BaseDtoExtension.NotNull("Telefone");
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
+
+        [Fact]
+        public void Schedule_WhenHaircutTimeIsUnavailable_ReturnsUnavailableError()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var haircutTime = "02/04/2004";
+            var dto = new ScheduleHaircutDto(userId, haircutTime, true, new ClientEntity("Bruno", "elefante@outlook.com", "40028922"));
+
+            _mockUserRepository.Setup(repo => repo.GetById(dto.UserID)).Returns(() =>
+            {
+                var user = new UserEntity { Id = dto.UserID };
+                user.Haircuts.Add(new HaircutEntity(dto.UserID, dto.HaircuteTime, true, dto.Client));
+                return user;
+            });
+
+            // Act
+            var actual = _scheduleHaircutService.Schedule(dto);
+            var expected = BaseDtoExtension.Create(200, "Horário indisponível");
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
+
+        [Fact]
+        public void Schedule_WhenClientAlreadyScheduled_ReturnsClientAlreadyScheduledError()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var haircutTime = "02/04/2004";
+            var dto = new ScheduleHaircutDto(userId, haircutTime, true, new ClientEntity("Bruno", "elefante@outlook.com", "40028922"));
+
+            var haircut = new HaircutEntity(userId, haircutTime, true, new ClientEntity("Bruno", "elefante@outlook.com", "40028922"));
+
+            var haircuts = new List<HaircutEntity> { haircut };
+
+            _mockUserRepository.Setup(repo => repo.GetById(dto.UserID)).Returns(new UserEntity { Id = userId });
+            _mockHaircutRepository.Setup(repo => repo.GetAll()).Returns(haircuts);
+
+            // Act
+            var actual = _scheduleHaircutService.Schedule(dto);
+            var expected = BaseDtoExtension.Create(406, $"Cliente {haircut.Client.Name} já agendado");
+
+            // Assert
+            Assert.Equal(expected._Message, actual._Message);
+            Assert.Equal(expected._StatusCode, actual._StatusCode);
+        }
+
+    }
+}


### PR DESCRIPTION
Criadas as classes de teste das services ScheduleHaircutService e PostImageService usando o Moq, Xunit e o padrão AAA. 

Casos testados da PostImageService:

1.  Quando o usuário não é encontrado;
2. Quando a imagem é nula, o teste retorna um erro com a mensagem de que a imagem não pode ser nula;
3. Quando o usuário e a imagem são válidos, o teste cria uma nova entidade de imagem com os bytes da imagem convertidos corretamente e o ID do usuário correspondente, retornando sucesso.

Casos testados da ScheduleHaircutService:

1. Quando a confirmação de corte não é encontrada;
2. Quando o Id do usuário não é encontrado;
3. Quando o usuário não é encontrado pelo seu Id correspondente;
4. Quando o horário está vazio;
5. Quando o nome do cliente está vazio;
6. Quando o telefone do cliente está vazio;
7. Quando o horário do corte já está ocupado por outro corte agendado para o mesmo usuário;
8. Quando o cliente já tem um corte agendado em um horário diferente;
9. Quando o agendamento é bem-sucedido.